### PR TITLE
use displayName for kerbin replacements

### DIFF
--- a/DiscordRP/States/EscapingState.cs
+++ b/DiscordRP/States/EscapingState.cs
@@ -30,14 +30,14 @@ namespace DiscordRP.States
 
         public DiscordRpc.RichPresence create()
         {
-            string state = state = string.Format("Escaping {0}", body.displayName);
+            string state = state = string.Format("Escaping {0}", body.name ?? body.displayName);
 
             return new DiscordRpc.RichPresence()
             {
                 state = state,
                 details = "At escape velocity",
-                largeImageKey = string.Format("body_{0}", body.displayName.ToLower()),
-                largeImageText = body.displayName,
+                largeImageKey = string.Format("body_{0}", body.displayName.ToLower() ?? body.name.ToLower()),
+                largeImageText = body.displayName ?? body.name,
                 startTimestamp = startTimestamp,
                 smallImageKey = Utils.GetSmallFlightIcon(paused),
                 smallImageText = Utils.GetSmallFlightIconDetails(paused),

--- a/DiscordRP/States/EscapingState.cs
+++ b/DiscordRP/States/EscapingState.cs
@@ -30,14 +30,14 @@ namespace DiscordRP.States
 
         public DiscordRpc.RichPresence create()
         {
-            string state = state = string.Format("Escaping {0}", body.name);
+            string state = state = string.Format("Escaping {0}", body.displayName);
 
             return new DiscordRpc.RichPresence()
             {
                 state = state,
                 details = "At escape velocity",
-                largeImageKey = string.Format("body_{0}", body.name.ToLower()),
-                largeImageText = body.name,
+                largeImageKey = string.Format("body_{0}", body.displayName.ToLower()),
+                largeImageText = body.displayName,
                 startTimestamp = startTimestamp,
                 smallImageKey = Utils.GetSmallFlightIcon(paused),
                 smallImageText = Utils.GetSmallFlightIconDetails(paused),

--- a/DiscordRP/States/FlyingState.cs
+++ b/DiscordRP/States/FlyingState.cs
@@ -34,13 +34,13 @@ namespace DiscordRP.States
 
         public DiscordRpc.RichPresence create()
         {
-            string state = state = string.Format("Flying over {0}", body.name);
+            string state = state = string.Format("Flying over {0}", body.displayName);
 
             return new DiscordRpc.RichPresence()
             {
                 state = state,
                 details = string.Format("Alt: {0:F0}m | Vel: {1:F0}m/s", altitude, velocity),
-                largeImageKey = string.Format("body_{0}", body.name.ToLower()),
+                largeImageKey = string.Format("body_{0}", body.displayName.ToLower()),
                 largeImageText = body.name,
                 startTimestamp = startTimestamp,
                 smallImageKey = Utils.GetSmallFlightIcon(paused),

--- a/DiscordRP/States/FlyingState.cs
+++ b/DiscordRP/States/FlyingState.cs
@@ -34,14 +34,14 @@ namespace DiscordRP.States
 
         public DiscordRpc.RichPresence create()
         {
-            string state = state = string.Format("Flying over {0}", body.displayName);
+            string state = state = string.Format("Flying over {0}", body.displayName ?? body.nme);
 
             return new DiscordRpc.RichPresence()
             {
                 state = state,
                 details = string.Format("Alt: {0:F0}m | Vel: {1:F0}m/s", altitude, velocity),
-                largeImageKey = string.Format("body_{0}", body.displayName.ToLower()),
-                largeImageText = body.name,
+                largeImageKey = string.Format("body_{0}", body.displayName.ToLower() ?? body.name.ToLower()),
+                largeImageText = body.displyName ?? body.name,
                 startTimestamp = startTimestamp,
                 smallImageKey = Utils.GetSmallFlightIcon(paused),
                 smallImageText = Utils.GetSmallFlightIconDetails(paused),

--- a/DiscordRP/States/LandedState.cs
+++ b/DiscordRP/States/LandedState.cs
@@ -40,8 +40,8 @@ namespace DiscordRP.States
             {
                 state = state,
                 details = string.Format("Lat: {0:F3} | Lng: {1:F3}", latitude, longitude),
-                largeImageKey = string.Format("body_{0}", body.name.ToLower()),
-                largeImageText = body.name,
+                largeImageKey = string.Format("body_{0}", body.displayName.ToLower()),
+                largeImageText = body.displayName,
                 startTimestamp = startTimestamp,
                 smallImageKey = Utils.GetSmallFlightIcon(paused),
                 smallImageText = Utils.GetSmallFlightIconDetails(paused),

--- a/DiscordRP/States/LandedState.cs
+++ b/DiscordRP/States/LandedState.cs
@@ -34,14 +34,14 @@ namespace DiscordRP.States
 
         public DiscordRpc.RichPresence create()
         {
-            string state = state = string.Format("Landed at {0}", body.name);
+            string state = state = string.Format("Landed at {0}", body.displayName ?? body.name);
 
             return new DiscordRpc.RichPresence()
             {
                 state = state,
                 details = string.Format("Lat: {0:F3} | Lng: {1:F3}", latitude, longitude),
-                largeImageKey = string.Format("body_{0}", body.displayName.ToLower()),
-                largeImageText = body.displayName,
+                largeImageKey = string.Format("body_{0}", body.displayName.ToLower() ?? body.name.ToLower()),
+                largeImageText = body.displayName ?? body.name,
                 startTimestamp = startTimestamp,
                 smallImageKey = Utils.GetSmallFlightIcon(paused),
                 smallImageText = Utils.GetSmallFlightIconDetails(paused),

--- a/DiscordRP/States/OrbitingState.cs
+++ b/DiscordRP/States/OrbitingState.cs
@@ -34,14 +34,14 @@ namespace DiscordRP.States
 
         public DiscordRpc.RichPresence create()
         {
-            string state = state = string.Format("Orbiting around {0}", body.name);
+            string state = state = string.Format("Orbiting around {0}", body.displyName);
 
             return new DiscordRpc.RichPresence()
             {
                 state = state,
                 details = string.Format("SMA: {0} | Ec: {1:F2}", Utils.FormatDistance(semiMajorAxis), eccentricity),
-                largeImageKey = string.Format("body_{0}", body.name.ToLower()),
-                largeImageText = body.name,
+                largeImageKey = string.Format("body_{0}", body.displayName.ToLower()),
+                largeImageText = body.displayName,
                 startTimestamp = startTimestamp,
                 smallImageKey = Utils.GetSmallFlightIcon(paused),
                 smallImageText = Utils.GetSmallFlightIconDetails(paused),

--- a/DiscordRP/States/OrbitingState.cs
+++ b/DiscordRP/States/OrbitingState.cs
@@ -40,8 +40,8 @@ namespace DiscordRP.States
             {
                 state = state,
                 details = string.Format("SMA: {0} | Ec: {1:F2}", Utils.FormatDistance(semiMajorAxis), eccentricity),
-                largeImageKey = string.Format("body_{0}", body.displayName.ToLower()),
-                largeImageText = body.displayName,
+                largeImageKey = string.Format("body_{0}", body.displayName.ToLower() ?? body.name.ToLower()),
+                largeImageText = body.displayName ? body.nme,
                 startTimestamp = startTimestamp,
                 smallImageKey = Utils.GetSmallFlightIcon(paused),
                 smallImageText = Utils.GetSmallFlightIconDetails(paused),

--- a/DiscordRP/States/SplashedState.cs
+++ b/DiscordRP/States/SplashedState.cs
@@ -34,14 +34,14 @@ namespace DiscordRP.States
 
         public DiscordRpc.RichPresence create()
         {
-            string state = state = string.Format("Splashed down at {0}", body.name);
+            string state = state = string.Format("Splashed down at {0}", body.displayName ?? body.name);
 
             return new DiscordRpc.RichPresence()
             {
                 state = state,
                 details = string.Format("Lat: {0:F3} | Lng: {1:F3}", latitude, longitude),
-                largeImageKey = string.Format("body_{0}", body.displayName.ToLower()),
-                largeImageText = body.displayName,
+                largeImageKey = string.Format("body_{0}", body.displayName.ToLower() ?? body.name.ToLower()),
+                largeImageText = body.displayName ?? body.name,
                 startTimestamp = startTimestamp,
                 smallImageKey = Utils.GetSmallFlightIcon(paused),
                 smallImageText = Utils.GetSmallFlightIconDetails(paused),

--- a/DiscordRP/States/SplashedState.cs
+++ b/DiscordRP/States/SplashedState.cs
@@ -40,8 +40,8 @@ namespace DiscordRP.States
             {
                 state = state,
                 details = string.Format("Lat: {0:F3} | Lng: {1:F3}", latitude, longitude),
-                largeImageKey = string.Format("body_{0}", body.name.ToLower()),
-                largeImageText = body.name,
+                largeImageKey = string.Format("body_{0}", body.displayName.ToLower()),
+                largeImageText = body.displayName,
                 startTimestamp = startTimestamp,
                 smallImageKey = Utils.GetSmallFlightIcon(paused),
                 smallImageText = Utils.GetSmallFlightIconDetails(paused),


### PR DESCRIPTION
Some mods replace kerbin, however limitations in ksp require the name to remain kerbin. To get around this, they use displayName. The changes I have proposed would show these planets names correctly.